### PR TITLE
replace_images.rb (single/multiple images mode)

### DIFF
--- a/http/replace_images.rb
+++ b/http/replace_images.rb
@@ -1,7 +1,7 @@
 
 =begin
 BETTERCAP
-Author : Simone 'evilsocket' Margaritelli
+Author : Simone 'evilsocket' Margaritelli & David Kotriksnov (SH4V)
 Email  : evilsocket@gmail.com
 Blog   : http://www.evilsocket.net/
 This project is released under the GPL 3 license.
@@ -9,33 +9,39 @@ This project is released under the GPL 3 license.
 
 # This module requires the --httpd argument being passed
 # to bettercap and the --httpd-path pointing to a folder
-# which contains a "hack.png" image.
+# which contains one or more images.
 class ReplaceImages < BetterCap::Proxy::HTTP::Module
   meta(
     'Name'        => 'ReplaceImages',
-    'Description' => 'Replace all images on web pages.',
-    'Version'     => '1.0.0',
-    'Author'      => "Simone 'evilsocket' Margaritelli",
+    'Description' => 'Replace all images on web pages by the picture(s) placed in the specified directory.',
+    'Version'     => '1.1.0',
+    'Author'      => "Simone 'evilsocket' Margaritelli & David Kotriksnov (SH4V)",
     'License'     => 'GPL3'
   )
+	def initialize
+		opts = BetterCap::Context.get.options.servers
+		@imgArray = Dir.entries("#{opts.httpd_path}")
+		@imgArray.pop
+		@imgArray.pop
+		# make sure the server is running
+		raise BetterCap::Error, "The ReplaceImages proxy module needs the HTTPD ( --httpd argument ) running."	unless opts.httpd
+		# make sure the file we need actually exists  
+		raise BetterCap::Error, "No files found in the HTTPD path ( --httpd-path argument ) '#{opts.httpd_path}'" \
+		unless @imgArray.length > 0
+			@images_path = "http://#{BetterCap::Context.get.iface.ip}:#{opts.httpd_port}/"
+	end
 
-  def initialize
-    opts = BetterCap::Context.get.options.servers
-    # make sure the server is running
-    raise BetterCap::Error, "The ReplaceImages proxy module needs the HTTPD ( --httpd argument ) running." unless opts.httpd
-    # make sure the file we need actually exists
-    raise BetterCap::Error, "No hack.png file found in the HTTPD path ( --httpd-path argument ) '#{opts.httpd_path}'" \
-      unless File.exist? "#{opts.httpd_path}/hack.png"
-
-    @image_url = "\"http://#{BetterCap::Context.get.iface.ip}:#{opts.httpd_port}/hack.png\""
-  end
-
-  def on_request( request, response )
-    # is it a html page?
-    if response.content_type =~ /^text\/html.*/
-      BetterCap::Logger.info "Replacing http://#{request.host}#{request.path} images."
-
-      response.body.gsub! %r/["'][https:\/\/]*[^\s]+\.(png|jpg|jpeg|bmp|gif)["']/i, @image_url
-    end
-  end
+	def on_request(request, response)
+		@image_file=@imgArray[rand(@imgArray.length)]
+		@image_url="\""+@images_path+@image_file+"\""
+		# is it a html page?
+		if response.content_type =~ /^text\/html.*/
+			BetterCap::Logger.info "Replacing http://#{request.host}#{request.path} images with #{@image_file}..."
+			response.body.gsub! %r/["'][https:\/\/]*[^\s]+\.(png|jpg|jpeg|bmp|gif)["']/i, @image_url
+			@image_url=nil
+		end
+	end
 end
+
+
+


### PR DESCRIPTION
Now the module is able to replace the original images by the one(s) placed in the specified path. Single or multiple images can be dropped in the directory, no matter the name of the files.
